### PR TITLE
New workflow to build and commit the build file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build File in master Branch
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-file:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, '[skip build]')"
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm install --force
+
+      - name: Update source code
+        run: npm run build
+
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: '[Automated] add build file'
+          add: 'dist/*'
+          default_author: github_actor


### PR DESCRIPTION
Heavily inspired by [devhaus-digital-readiness-assessment-quiz](https://github.com/BuildWithDevhaus/devhaus-digital-readiness-assessment-quiz)'s workflow combined with some best practice library to do this actions.

### What it does?
This workflow will automatically adding the build file on every push to `master`
![image](https://user-images.githubusercontent.com/129720480/234777848-7127f0cb-49fc-4413-a438-e0347e646fe8.png)

### Action Needed
The only changes needed is set workflow permissions to have `Read and Write` access on the actions settings
1. Click on `Settings`
![image](https://user-images.githubusercontent.com/129720480/234778436-6554052f-aa52-4823-9c22-ee05631e72f6.png)
2. navigate to `Actions` > `General`
![image](https://user-images.githubusercontent.com/129720480/234778632-ec4fc143-3f89-4916-ab1d-c92fc2f9ad16.png)
3. Change the workflow permission to `Read and Write`
![image](https://user-images.githubusercontent.com/129720480/234777710-d9a17e97-830a-4641-9cbb-ba069c5e2869.png)


### Skip Build file
In order to skip building process, the only action needed is just add `[skip build]` on commit message.
![image](https://user-images.githubusercontent.com/129720480/234779065-0c3f3d23-262f-4620-be00-bfb57acc96c0.png)
